### PR TITLE
Fix code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/user_api.py
+++ b/user_api.py
@@ -7,7 +7,7 @@ from flask_cors import CORS
 import time
 import sqlite3
 from sys_analyze_api import systemAnalyzer
-
+import logging
 
 class Database:
     """Class responsible for interacting with the SQLite database for request limits."""
@@ -141,8 +141,9 @@ class App:
             return jsonify(statistics), 200
 
         except Exception as e:
-            # Log the error (not shown here, but would be logged in a real application)
-            return jsonify({'error': f'Internal server error: {str(e)}'}), 500
+            # Log the error
+            logging.error(f"Internal server error: {str(e)}")
+            return jsonify({'error': 'An internal error has occurred. Please try again later.'}), 500
 
     def run(self):
         """Run the Flask app."""


### PR DESCRIPTION
Fixes [https://github.com/kavineksith/System-Analyzer-API/security/code-scanning/3](https://github.com/kavineksith/System-Analyzer-API/security/code-scanning/3)

To fix the problem, we need to ensure that detailed error messages are not exposed to end users. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code in the `get_report` method to log the error and return a generic message.

- Modify the exception handling block in the `get_report` method to log the detailed error message and return a generic error message to the user.
- Add an import statement for the `logging` module to enable logging of error messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
