### PR TITLE
Fix code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/sys_analyze_api.py
+++ b/sys_analyze_api.py
@@ -37,7 +37,7 @@ class SystemAnalyzer:
 
         except Exception as e:
             logger.error(f"Error generating all-in-one report: {e}")
-            return jsonify({'error': f'Error in generating all-in-one report: {e}'}), 500
+            return jsonify({'error': 'An internal error has occurred while generating the report.'}), 500
 
     @staticmethod
     def once_status_one_report(token):
@@ -65,4 +65,4 @@ class SystemAnalyzer:
             return jsonify({'error': f'Value error: {ve}'}), 400
         except Exception as e:
             logger.error(f"Error executing report for token {token}: {e}")
-            return jsonify({'error': f'Error executing report: {e}'}), 500
+            return jsonify({'error': 'An internal error has occurred while executing the report.'}), 500


### PR DESCRIPTION
Fixes [https://github.com/kavineksith/System-Analyzer-API/security/code-scanning/5](https://github.com/kavineksith/System-Analyzer-API/security/code-scanning/5)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

- Modify the exception handling code in the `all_in_one` and `once_status_one_report` methods to log the detailed error message and return a generic error message to the user.
- Ensure that the logging configuration is already set up to capture the detailed error messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
