### PR TITLE
Fix code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/user_api.py
+++ b/user_api.py
@@ -161,8 +161,8 @@ class App:
             return jsonify(statistics), 200
 
         except Exception as e:
-            logger.error(f"Internal server error: {e}")
-            return jsonify({'error': f'Internal server error: {str(e)}'}), 500
+            logger.error(f"Internal server error: {e}", exc_info=True)
+            return jsonify({'error': 'An internal error has occurred. Please try again later.'}), 500
 
     def run(self):
         """Run the Flask app."""


### PR DESCRIPTION
Fixes [https://github.com/kavineksith/System-Analyzer-API/security/code-scanning/3](https://github.com/kavineksith/System-Analyzer-API/security/code-scanning/3)

To fix the problem, we need to ensure that detailed exception messages and stack traces are not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

- Modify the exception handling block in the `get_report` method to log the detailed error message and return a generic error message to the user.
- Ensure that the logging configuration is already set up to capture and store the detailed error messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
