### PR TITLE
Fix code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/sys_analyze_api.py
+++ b/sys_analyze_api.py
@@ -46,7 +46,7 @@ class SystemAnalyzer:
 
         except Exception as e:
             logger.error(f"Error generating all-in-one report: {e}")
-            return jsonify({'error': f'Error in generating all-in-one report: {e}'}), 500
+            return jsonify({'error': 'An internal error has occurred while generating the all-in-one report.'}), 500
 
     @staticmethod
     def once_status_one_report(token):
@@ -74,4 +74,4 @@ class SystemAnalyzer:
             return jsonify({'error': f'Value error: {ve}'}), 400
         except Exception as e:
             logger.error(f"Error executing report for token {token}: {e}")
-            return jsonify({'error': f'Error executing report: {e}'}), 500
+            return jsonify({'error': 'An internal error has occurred while executing the report.'}), 500


### PR DESCRIPTION
Fixes [https://github.com/kavineksith/System-Analyzer-API/security/code-scanning/5](https://github.com/kavineksith/System-Analyzer-API/security/code-scanning/5)

To fix the problem, we need to modify the code to return a generic error message to the user instead of including the exception message in the response. The detailed error message should be logged on the server for debugging purposes. This can be achieved by changing the return statements in the exception handling blocks to return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
