### PR TITLE
Fix code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/sys_analyze_api.py
+++ b/sys_analyze_api.py
@@ -71,7 +71,7 @@ class SystemAnalyzer:
                     raise ValueError('Invalid selection. Please enter a number between 1 and 7.')
         except ValueError as ve:
             logger.warning(f"Value error: {ve}")
-            return jsonify({'error': f'Value error: {ve}'}), 400
+            return jsonify({'error': 'Invalid input. Please enter a valid number between 1 and 7.'}), 400
         except Exception as e:
             logger.error(f"Error executing report for token {token}: {e}")
             return jsonify({'error': 'An internal error has occurred while executing the report.'}), 500


### PR DESCRIPTION
Fixes [https://github.com/kavineksith/System-Analyzer-API/security/code-scanning/4](https://github.com/kavineksith/System-Analyzer-API/security/code-scanning/4)

To fix the problem, we need to ensure that the exception message is not directly exposed to the user. Instead, we should log the detailed error message and return a generic error message to the user. This can be achieved by modifying the `once_status_one_report` method to log the `ValueError` and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
